### PR TITLE
🩹 [Patch]: Update Dependabot configuration to include labels for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,8 @@ version: 2
 updates:
   - package-ecosystem: github-actions # See documentation for possible values
     directory: / # Location of package manifests
+    labels:
+      - dependencies
+      - github-actions
     schedule:
       interval: weekly


### PR DESCRIPTION
## Description

This pull request makes a small configuration improvement to the Dependabot settings for GitHub Actions. It adds labels to automatically categorize pull requests created for GitHub Actions dependency updates.

- Added `dependencies` and `github-actions` labels to Dependabot PRs for GitHub Actions updates in `.github/dependabot.yml`.